### PR TITLE
feat: Wearable Sets Page with Total cost calculated with Baazaar Floor Price

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -58,7 +58,7 @@ export default function App() {
                                 <Switch>
                                     <Route exact path={`/`} component={ Main } />
                                     <Route exact path={`/market`} component={ Baazaar } />
-                                    <Route exact path={`/market/set`} component={ WearableSets } />
+                                    <Route exact path={`/market/sets`} component={ WearableSets } />
                                     <Route exact path={`/explorer`} component={ GhostExplorer } />
                                     <Route path={`/guilds`} component={ Guilds } />
                                     <Route path={`/client`} component={ Client } />

--- a/src/App.js
+++ b/src/App.js
@@ -10,6 +10,7 @@ import Footer from './root/Footer/Footer';
 
 import Main from './pages/Main/Main';
 import Baazaar from './pages/Baazaar/Baazaar';
+import WearableSets from './pages/WearableSets/WearableSets';
 import GhostExplorer from './pages/GhostExplorer/GhostExplorer';
 import Guilds from './pages/Guilds/Guilds';
 import Client from './pages/Client/Client';
@@ -57,6 +58,7 @@ export default function App() {
                                 <Switch>
                                     <Route exact path={`/`} component={ Main } />
                                     <Route exact path={`/market`} component={ Baazaar } />
+                                    <Route exact path={`/market/set`} component={ WearableSets } />
                                     <Route exact path={`/explorer`} component={ GhostExplorer } />
                                     <Route path={`/guilds`} component={ Guilds } />
                                     <Route path={`/client`} component={ Client } />

--- a/src/api/common/queries.js
+++ b/src/api/common/queries.js
@@ -309,3 +309,15 @@ export const raffleWinsQuery = (address) => {
       }
     }`
 };
+
+export const wearableSetsQuery = () => {
+  return `{
+    wearableSets {
+      id
+      name
+      allowedCollaterals
+      wearableIds
+      traitBonuses
+    }
+  }`
+}

--- a/src/api/thegraph.js
+++ b/src/api/thegraph.js
@@ -16,7 +16,8 @@ import {
     parselQuery,
     clientParselQuery,
     listedParcelQuery,
-    getParcelHistoricalPricesQuery
+    getParcelHistoricalPricesQuery,
+    wearableSetsQuery
 } from './common/queries';
 import Web3 from 'web3';
 
@@ -394,5 +395,14 @@ export default {
         });
 
         return queries;
+    },
+
+    async getAllWearableSets() {
+        const { 
+            data: {
+                wearableSets
+            } 
+        } = await this.getData(wearableSetsQuery())
+        return wearableSets
     }
 }

--- a/src/components/Items/ERC1155/ERC1155.js
+++ b/src/components/Items/ERC1155/ERC1155.js
@@ -33,7 +33,7 @@ export default function ERC1155({children, item}) {
 
     useEffect(() => {
         let controller = new AbortController();
-        if (!item.priceInWei && item.priceInWei !== 0) {
+        if (!item.priceInGhst) {
             // last sold
             thegraph.getErc1155Price(item.id, true, item.category, 'timeLastPurchased', 'desc').then((response) => {
                 if(!controller.signal.aborted) {
@@ -62,7 +62,7 @@ export default function ERC1155({children, item}) {
 
             {(item.balance || item.priceInWei) ? (
                 <div className={classes.labels}>
-                    {(item.priceInWei || (last && current)) ? (
+                    {(item.priceInGhst || (last && current)) ? (
                         <Tooltip title='Total value' classes={{ tooltip: classes.customTooltip }} placement='top' followCursor>
                             <div
                                 className={
@@ -75,11 +75,13 @@ export default function ERC1155({children, item}) {
                             >
                                 <Typography variant='subtitle2'>
                                     {
-                                        (item.priceInWei && (item.priceInWei === Infinity ? '???' : item.priceInWei)) || 
-                                        (last?.price === 0 && !item.priceInWei 
-                                            ? '???'
-                                            : commonUtils.formatPrice((last?.price && item.balance)
-                                                ? (last?.price * item.balance)
+                                        (item.priceInGhst && item.priceInGhst === Infinity 
+                                            ? '???' 
+                                            : item.priceInGhst) || 
+                                        (last.price === 0 && !item.priceInWei 
+                                            ? '???' 
+                                            : commonUtils.formatPrice((last.price && item.balance) 
+                                                ? (last.price * item.balance) 
                                                 : parseFloat(web3.utils.fromWei(item.priceInWei))))
                                     }
                                 </Typography>
@@ -151,7 +153,7 @@ export default function ERC1155({children, item}) {
 
             {children}
 
-            {!item.priceInWei && (
+            {!item.priceInGhst && ( // Hide below for wearable sets
                 <div className={classes.prices}>
                     {current && last ? (
                         <Tooltip

--- a/src/components/Items/Wearable/Wearable.js
+++ b/src/components/Items/Wearable/Wearable.js
@@ -26,7 +26,8 @@ export default function Wearable({wearable, raffleChances, tooltip}) {
             slot: slot,
             tooltip: tooltip,
             priceInWei: wearable.priceInWei,
-            quantity: wearable.quantity
+            quantity: wearable.quantity,
+            lastSale: wearable.lastSale
         }}>
 
             <div className={classes.iconWrapper}>

--- a/src/components/Items/Wearable/Wearable.js
+++ b/src/components/Items/Wearable/Wearable.js
@@ -25,9 +25,9 @@ export default function Wearable({wearable, raffleChances, tooltip}) {
             holders: wearable.holders,
             slot: slot,
             tooltip: tooltip,
-            priceInWei: wearable.priceInWei,
-            quantity: wearable.quantity,
-            lastSale: wearable.lastSale
+            priceInGhst: wearable.priceInGhst, // For Wearable Sets
+            priceInWei: wearable.priceInWei, // For Market -> Activity
+            quantity: wearable.quantity
         }}>
 
             <div className={classes.iconWrapper}>

--- a/src/hooks/useFetchAllWearableSets.js
+++ b/src/hooks/useFetchAllWearableSets.js
@@ -1,0 +1,24 @@
+import { useState, useCallback } from 'react'
+import thegraph from '../api/thegraph';
+
+
+export default function useFetchAllWearableSets() {
+	const [isLoading, setIsLoading] = useState(false)
+	const [error, setError] = useState(null)
+	const [wearableSets, setWearableSets] = useState([])
+
+	const fetchAllWearableSets = useCallback(async () => {
+		setIsLoading(true)
+		setError(null)
+		try {
+			const data = await thegraph.getAllWearableSets()
+			setWearableSets(data)
+		} catch (error) {
+			setWearableSets([])
+			setError(error)
+		}
+		setIsLoading(false)
+	}, [])
+
+	return [{ isLoading, wearableSets, error }, fetchAllWearableSets]
+}

--- a/src/hooks/useFetchAllWearables.js
+++ b/src/hooks/useFetchAllWearables.js
@@ -1,0 +1,44 @@
+import { useState, useCallback } from 'react'
+import thegraph from '../api/thegraph';
+import itemUtils from '../utils/itemUtils';
+
+
+export default function useFetchAllWearableSets() {
+	const [isLoading, setIsLoading] = useState(false)
+	const [error, setError] = useState(null)
+	const [wearables, setWearables] = useState({})
+
+	const fetchAllWearableSets = useCallback(async () => {
+		setIsLoading(true)
+		setError(null)
+		const items = itemUtils.getIds()
+			.map((id) => ({
+				id: +id,
+				rarity: itemUtils.getItemRarityById(id),
+				rarityId: itemUtils.getItemRarityId(itemUtils.getItemRarityById(id)),
+				balance: 1,
+				category: id >= 126 && id <= 129 ? 2 : 0 // TODO: temporary solution to determine if item is consumable or not
+			}))
+		try {
+
+			const data = await Promise.all(items
+				.map(async item => { 
+						const { price: priceInWei } = await thegraph.getErc1155Price(item.id, false, item.category, 'priceInWei', 'asc')
+						return {
+							[item.id]: {
+								...item,
+								priceInWei: priceInWei === 0 ? Infinity : priceInWei
+							}
+						}
+				}))
+				
+			setWearables(data.reduce((r, c) => Object.assign(r, c), {}))
+		} catch (error) {
+			setWearables([])
+			setError(error)
+		}
+		setIsLoading(false)
+	}, [])
+
+	return [{ isLoading, wearables, error }, fetchAllWearableSets]
+}

--- a/src/hooks/useFetchAllWearables.js
+++ b/src/hooks/useFetchAllWearables.js
@@ -23,11 +23,11 @@ export default function useFetchAllWearableSets() {
 
 			const data = await Promise.all(items
 				.map(async item => { 
-						const { price: priceInWei } = await thegraph.getErc1155Price(item.id, false, item.category, 'priceInWei', 'asc')
+						const { price: priceInGhst } = await thegraph.getErc1155Price(item.id, false, item.category, 'priceInWei', 'asc')
 						return {
 							[item.id]: {
 								...item,
-								priceInWei: priceInWei === 0 ? Infinity : priceInWei
+								priceInGhst: priceInGhst === 0 ? Infinity : priceInGhst
 							}
 						}
 				}))

--- a/src/pages/WearableSets/SortingButtonGroup.js
+++ b/src/pages/WearableSets/SortingButtonGroup.js
@@ -1,0 +1,33 @@
+import { useCallback } from 'react'
+import { ToggleButton, ToggleButtonGroup } from '@mui/material';
+import ArrowDownwardIcon from '@mui/icons-material/ArrowDownward';
+import ArrowUpwardIcon from '@mui/icons-material/ArrowUpward';
+import ghst from '../../assets/images/ghst-doubleside.gif';
+import styles from './styles';
+
+export default function SortingButtonGroup({ value, onChange }) {
+	const classes = styles();
+	const handleChange = useCallback((evt, value) => {
+		onChange(value)
+	}, [onChange])
+	return (
+		<ToggleButtonGroup
+			value={value}
+			exclusive
+			onChange={handleChange}
+			color='primary'
+			aria-label='gotchis sort'
+			// fullWidth
+			size={'small'}
+		>
+			<ToggleButton className={classes.toggleItem} value={'priceInWei-asc'} aria-label='modified rarity score'>
+				<img src={ghst} alt='ghst' />
+				<ArrowDownwardIcon />
+			</ToggleButton>
+			<ToggleButton className={classes.toggleItem} value={'priceInWei-desc'} aria-label='modified rarity score'>
+				<img src={ghst} alt='ghst' />
+				<ArrowUpwardIcon />
+			</ToggleButton>
+		</ToggleButtonGroup>
+	)
+}

--- a/src/pages/WearableSets/SortingButtonGroup.js
+++ b/src/pages/WearableSets/SortingButtonGroup.js
@@ -20,11 +20,11 @@ export default function SortingButtonGroup({ value, onChange }) {
 			// fullWidth
 			size={'small'}
 		>
-			<ToggleButton className={classes.toggleItem} value={'priceInWei-asc'} aria-label='modified rarity score'>
+			<ToggleButton className={classes.toggleItem} value={'priceInGhst-asc'} aria-label='modified rarity score'>
 				<img src={ghst} alt='ghst' />
 				<ArrowDownwardIcon />
 			</ToggleButton>
-			<ToggleButton className={classes.toggleItem} value={'priceInWei-desc'} aria-label='modified rarity score'>
+			<ToggleButton className={classes.toggleItem} value={'priceInGhst-desc'} aria-label='modified rarity score'>
 				<img src={ghst} alt='ghst' />
 				<ArrowUpwardIcon />
 			</ToggleButton>

--- a/src/pages/WearableSets/WearableSets.js
+++ b/src/pages/WearableSets/WearableSets.js
@@ -1,0 +1,88 @@
+import React, { useMemo, useEffect, useState } from 'react';
+import { Box  } from '@mui/material';
+
+import styles from './styles';
+import ghstIcon from '../../assets/images/ghst-doubleside.gif';
+import useFetchAllWearableSets from '../../hooks/useFetchAllWearableSets';
+import useFetchAllWearables from '../../hooks/useFetchAllWearables';
+import Wearable from '../../components/Items/Wearable/Wearable'; 
+import GhostLoader from '../../components/GhostLoader/GhostLoader';
+import itemUtils from '../../utils/itemUtils';
+import SortingButtonGroup from './SortingButtonGroup'
+
+export default function WearableSets() { 
+    const classes = styles();
+    const [sorting, setSorting] = useState()
+    const [{ isLoading: isFetchingWearableSets, wearableSets }, fetchAllWearableSets] = useFetchAllWearableSets()
+    const [{ isLoading: isFetchingWearables, wearables: wearablesMap }, fetchAllWearables] = useFetchAllWearables()
+
+    useEffect(() => {
+      fetchAllWearableSets()
+      fetchAllWearables()
+    }, [fetchAllWearableSets, fetchAllWearables])
+
+
+    const isLoading = useMemo(() => isFetchingWearableSets || isFetchingWearables, [isFetchingWearableSets, isFetchingWearables])
+
+    const sortedSets = useMemo(() => {
+        if (isLoading) {
+            return []
+        }
+
+        const sets = wearableSets.map(set => {
+            const wearables = set.wearableIds.map((id) => wearablesMap[id])
+            if (!wearables.reduce((acc, { priceInWei }) => acc + priceInWei, 0)) {
+                console.log(wearables)
+            }
+            return ({
+                ...set,
+                wearables,
+                totalCost: wearables.reduce((acc, { priceInWei }) => acc + priceInWei, 0)
+            })
+        })
+        if (sorting === 'priceInWei-asc') {
+            return sets.sort((a, b) => a.totalCost - b.totalCost)
+        }
+
+        if (sorting === 'priceInWei-desc') {
+            return sets.sort((a, b) => b.totalCost - a.totalCost)
+        }
+
+        return sets
+        // return wearableSets
+    }, [isLoading, sorting, wearableSets, wearablesMap])
+
+    if(isLoading) {
+        return (
+        <Box textAlign='center' paddingTop={'32px'}>
+            <GhostLoader animate={isLoading} />
+        </Box>)
+    }
+
+    return (
+        <div className={classes.container}>
+            <SortingButtonGroup value={sorting} onChange={setSorting} />
+            {
+                sortedSets.map((set, i) => {
+                    const totalCost = set.totalCost === Infinity ? '???' : set.totalCost
+                    return (
+                        <div key={set.id}>
+                            <h3 className={classes.title}>
+                                {set.name} ({totalCost}<img src={ghstIcon} width='24' height='24' alt='GHST Token Icon' />) {itemUtils.getEmojiStats(set.traitBonuses)}
+                            </h3>
+                            <Box className={classes.list}>
+                                {set.wearables.map((item, index) => {
+                                    return (
+                                        <div className={classes.listItem} key={`${set.id}-${index}`}>
+                                            <Wearable wearable={item} />
+                                        </div>
+                                    )
+                                })}
+                            </Box>
+                        </div>
+                    )
+                })
+            }
+        </div>
+    );
+}

--- a/src/pages/WearableSets/WearableSets.js
+++ b/src/pages/WearableSets/WearableSets.js
@@ -31,13 +31,10 @@ export default function WearableSets() {
 
         const sets = wearableSets.map(set => {
             const wearables = set.wearableIds.map((id) => wearablesMap[id])
-            if (!wearables.reduce((acc, { priceInWei }) => acc + priceInWei, 0)) {
-                console.log(wearables)
-            }
             return ({
                 ...set,
                 wearables,
-                totalCost: wearables.reduce((acc, { priceInWei }) => acc + priceInWei, 0)
+                totalCost: Math.round(wearables.reduce((acc, { priceInWei }) => acc + priceInWei, 0) * 10) / 10
             })
         })
         if (sorting === 'priceInWei-asc') {

--- a/src/pages/WearableSets/WearableSets.js
+++ b/src/pages/WearableSets/WearableSets.js
@@ -34,19 +34,18 @@ export default function WearableSets() {
             return ({
                 ...set,
                 wearables,
-                totalCost: Math.round(wearables.reduce((acc, { priceInWei }) => acc + priceInWei, 0) * 10) / 10
+                totalCost: Math.round(wearables.reduce((acc, { priceInGhst }) => acc + priceInGhst, 0) * 10) / 10
             })
         })
-        if (sorting === 'priceInWei-asc') {
+        if (sorting === 'priceInGhst-asc') {
             return sets.sort((a, b) => a.totalCost - b.totalCost)
         }
 
-        if (sorting === 'priceInWei-desc') {
+        if (sorting === 'priceInGhst-desc') {
             return sets.sort((a, b) => b.totalCost - a.totalCost)
         }
 
         return sets
-        // return wearableSets
     }, [isLoading, sorting, wearableSets, wearablesMap])
 
     if(isLoading) {

--- a/src/pages/WearableSets/styles.js
+++ b/src/pages/WearableSets/styles.js
@@ -1,0 +1,46 @@
+ import { makeStyles } from "@mui/styles"; 
+
+const styles = makeStyles( theme => ({
+    container: {
+        padding: theme.spacing(3),
+        display: 'flex',
+        flexDirection: 'column'
+    },
+    buttonsRow: {
+        display: 'flex',
+        justifyContent: 'center',
+        alignItems: 'center',
+    },
+    title: {
+        display: 'flex',
+        alignItems: 'center'
+    },
+    list: {
+        display: 'grid',
+        alignItems: 'start',
+        gap: 12,
+        gridTemplateColumns: 'repeat(auto-fill, minmax(192px, 1fr))',
+        gridAutoRows: '1fr'
+    },
+    listItem: {
+        height: '100%',
+        paddingBottom: 12
+    },
+    toggleItem: {
+        fontSize: '12px',
+        padding: 8,
+        '& img': {
+            maxWidth: 16,
+            maxHeight: 16
+        },
+        '& .MuiSvgIcon-root': {
+            maxWidth: 16,
+            maxHeight: 16
+        }
+    },
+
+}));
+ 
+export {
+    styles as default
+};

--- a/src/utils/itemUtils.js
+++ b/src/utils/itemUtils.js
@@ -2,6 +2,10 @@ import { items } from '../data/items';
 
 // eslint-disable-next-line import/no-anonymous-default-export
 export default {
+    getIds() {
+        return Object.keys(items)
+    },
+
     getItemNameById(id) {
         return items[id]?.name || '';
     },
@@ -36,6 +40,26 @@ export default {
             }
         });
 
+        return stats;
+    },
+
+    // traitBonuses = [3, -1, 0, 2, 0] <- [BRS, NRG, AGG, SPK, BRN]
+    getEmojiStats(traitBonuses) {
+        if(!Array.isArray(traitBonuses)) return '';
+
+        let emojis = ['BRS', '⚡️', '👹', '👻', '🧠']
+        let stats = ""
+        traitBonuses.forEach((trait, index) => {
+            if (trait !== 0 && stats !== "") {
+                stats += ', '
+            }
+
+            if (trait > 0) {
+                stats += `${emojis[index]}+${trait}`
+            } else if (trait < 0) {
+                stats += `${emojis[index]}${trait}`
+            }
+        })
         return stats;
     },
 


### PR DESCRIPTION
# Adding feature: Wearable Sets Page with Total cost calculated with Baazaar Floor Price

The location of the feature: `http://localhost:3005/market/set`

![Screenshot 2022-02-14 at 9 02 47 PM](https://user-images.githubusercontent.com/30591224/153869222-4e91c1b9-53f1-4974-ae2e-e5e38ccb1b9e.png)

### Notes

1. Feel free to suggest UI changes as I know the UI design may not be fancy enough
2. `src/components/Items/ERC1155/ERC1155.js` and `src/components/Items/Wearable/Wearable.js` are refactored which may affect other pages
3. Only sorting on Total GHST cost is implemented. Feel free to suggest any other sorting
4. There are no way to navigate to the page from the UI at the moment, please suggest where to put the button to navigate to the Wearable Sets page